### PR TITLE
Add a class to any users that are admins

### DIFF
--- a/cpusergroup/CpUserGroupPlugin.php
+++ b/cpusergroup/CpUserGroupPlugin.php
@@ -75,6 +75,11 @@ class CpUserGroupPlugin extends BasePlugin
 		foreach ($user->getGroups() as $group) {
 			$this->_bodyClasses[] = $prefix.'-'.$group->handle;
 		}
+
+		// Identify users that are admins
+		if ($user['admin']) {
+			$this->_bodyClasses[] = $prefix.'-'."admin";
+		}
 	}
 
 	private function _setUserGroupClasses()


### PR DESCRIPTION
It looks like a `usergroup-admin` class isn't getting added in so I'm accounting for that here. Sometimes there's a case to hide a field from anyone who isn't a full blown admin.

```css
/* Hide the very secret field from any non-admins */
body:not(.usergroup-admin) #fields-shhVerySecret-field {
  display: none;
}
```